### PR TITLE
Samlet fravær procent med kommatal, fraværende moduler graf kan vise 50% fravær (0,5) rigtigt.

### DIFF
--- a/src/routes/fravær/+page.svelte
+++ b/src/routes/fravær/+page.svelte
@@ -60,7 +60,7 @@
             label: "Fraværende moduler",
             data: $fravaer.data.generalt
               .filter((element) => element.hold != "Samlet" && element.fravær_procent != "0,00%")
-              .map((element) => /([0-9]+)\//g.exec(element.fravær_moduler)[1]),
+              .map((element) => /(\d+\,?\d*|\,\d+)\//g.exec(element.fravær_moduler)[1].replace(",", ".")),
             backgroundColor: $fravaer.data.generalt.map(
               (element, index) => BACKGROUND_COLORS[index % BACKGROUND_COLORS.length]
             ),
@@ -68,6 +68,7 @@
         ],
       },
       options: {
+        locale: "da",
         scales: {
           x: {
             title: {

--- a/src/routes/fravær/+page.svelte
+++ b/src/routes/fravær/+page.svelte
@@ -46,7 +46,7 @@
     sort("procent"); // Altid sorter efter fravær procent først
     $fravaer.data.generalt.forEach((element) => {
       if (element.hold == "Samlet") {
-        samletFravaer = parseFloat(element.fravær_procent);
+        samletFravaer = element.fravær_procent;
       }
     });
     new Chart(modulerChartElement, {
@@ -130,6 +130,9 @@
               display: true,
               text: "Registreret fravær",
             },
+            ticks: {
+              precision: 0,
+            },
           },
         },
         plugins: {
@@ -181,10 +184,10 @@
 
 <h1 class="text-3xl font-bold">Fravær</h1>
 {#if $fravaer?.data && fravaer != null}
-  {#if samletFravaer == 0}
+  {#if samletFravaer == "0,00%"}
     <p>Du har intet fravær</p>
   {:else}
-    <p>Du har {samletFravaer}% fravær</p>
+    <p>Du har {samletFravaer} fravær</p>
     <p>Hold uden fravær er ikke vist</p>
     <div class="mb-4 mt-4">
       <table class="table w-full rounded-xl shadow-xl">


### PR DESCRIPTION
Samlet fravær rundet er rimeligt dumt:
![image](https://user-images.githubusercontent.com/64006750/208687590-c46dae70-097b-42e3-83ca-a670217fa897.png)

Før ville den vise 5 fraværende moduler i stedet for 0,5:
![image](https://user-images.githubusercontent.com/64006750/208687344-80a73d60-17b9-458b-82fb-f77af2c10e75.png)

Registreret fravær per måned's y-akse viser nu ikke komma tal længere (0,5 1,5 2,5...). Det er umuligt at få et kommatal som antal registreret fravær...
![image](https://user-images.githubusercontent.com/64006750/208688051-695a5d41-6b84-4bf3-9cc9-6be5e9c16e2b.png)