### PR TITLE
Ændret skema-sprog til dansk

### DIFF
--- a/src/routes/skema/+page.svelte
+++ b/src/routes/skema/+page.svelte
@@ -82,6 +82,7 @@
   let addedEventsId = [];
 
   let options = {
+    locale: "da",
     view: "timeGridWeek",
     nowIndicator: true,
     theme: customTheme,
@@ -90,6 +91,7 @@
     slotMinTime: "08:00:00",
     slotMaxTime: "17:00:00",
     events: [],
+    dayHeaderFormat: {weekday: 'long', day: 'numeric', month: 'numeric'},
     buttonText: {today: 'I dag', dayGridMonth: 'måned', listDay: 'list', listWeek: 'list', listMonth: 'list', listYear: 'list', resourceTimeGridDay: 'dag', resourceTimeGridWeek: 'uge', timeGridDay: 'dag', timeGridWeek: 'uge'},
     eventDidMount: (event) => {
       addedEventsId.push(event.event.id);


### PR DESCRIPTION
Tror kun det indflyder ugedagene. Jeg er ikke sikker på, hvorfor de ikke har stort startbugstav, men det er sådan `Intl.DateTimeFormat` viser ugedage på dansk 🤷 

![image](https://user-images.githubusercontent.com/64006750/211120814-509af50c-4205-4c75-87d1-0764a384e0ee.png)
![image](https://user-images.githubusercontent.com/64006750/211120828-5d8c7146-2d7f-46c3-b949-e3df2b8bd19e.png)

