### PR TITLE
Add image preview for message attachments

### DIFF
--- a/src/lib/js/http.js
+++ b/src/lib/js/http.js
@@ -104,7 +104,8 @@ export async function getDocument(id, docType = null) {
 			headers:
 			{
 				'lectio-cookie': localStorage.getItem('lectio-cookie'),
-				'Access-Control-Allow-Origin': '*'
+				'Access-Control-Allow-Origin': '*',
+				'content-type': 'image/jpg'
 			}
 		}, { method: 'GET' });
 

--- a/src/lib/js/http.js
+++ b/src/lib/js/http.js
@@ -96,16 +96,16 @@ export async function post(endpoint, body) {
 }
 
 
-export async function getDocument(id, docType = null) {
+export async function getDocument(id, docType = null, expectedContentType = 'image/*') {
 	let url = `${api}/dokument_hent?id=${id}`;
-	if (docType) url += `&doctype=${docType}`;
+	if (docType) url += `&doctype=${docType}&raw=true`;
 	const response = await fetch(url,
 		{
 			headers:
 			{
 				'lectio-cookie': localStorage.getItem('lectio-cookie'),
 				'Access-Control-Allow-Origin': '*',
-				'content-type': 'image/jpg'
+				'content-type': expectedContentType
 			}
 		}, { method: 'GET' });
 

--- a/src/lib/js/http.js
+++ b/src/lib/js/http.js
@@ -96,8 +96,9 @@ export async function post(endpoint, body) {
 }
 
 
-export async function getDocument(id) {
-	const url = `${api}/dokument_hent?id=${id}`;
+export async function getDocument(id, docType = null) {
+	let url = `${api}/dokument_hent?id=${id}`;
+	if (docType) url += `&doctype=${docType}`;
 	const response = await fetch(url,
 		{
 			headers:

--- a/src/routes/besked/+page.svelte
+++ b/src/routes/besked/+page.svelte
@@ -123,8 +123,9 @@
 				img.className = 'rounded-xl';
 
 				// append the image to the div
-				MessageAttachments = [...MessageAttachments, img];
-				return img;
+				MessageAttachments = [...MessageAttachments, url];
+				console.log(MessageAttachments);
+				return url;
 			});
 		});
 	}
@@ -186,7 +187,7 @@
 						{/each}
 
 						{#each MessageAttachments as attachment}
-							{@html sanitize(md.render(`![${attachment.alt}](${attachment.src})`))}
+							<img src={attachment} alt="" class="rounded-xl h-32" />
 						{/each}
 					</div>
 					<p class="mb-10" use:previewLink>

--- a/src/routes/besked/+page.svelte
+++ b/src/routes/besked/+page.svelte
@@ -100,21 +100,32 @@
 
 	let MessageAttachments = [];
 	async function fetchMessageAttachment(attachment) {
+		console.log(attachment);
+
+		// determine the most likely filetype based on file extension
+		let fileType = 'application/octet-stream';
+		if (attachment.navn.endsWith('.pdf')) fileType = 'application/pdf';
+		else if (attachment.navn.endsWith('.png')) fileType = 'image/png';
+		else if (attachment.navn.endsWith('.jpg')) fileType = 'image/jpg';
+		else if (attachment.navn.endsWith('.jpeg')) fileType = 'image/jpeg';
+		else if (attachment.navn.endsWith('.gif')) fileType = 'image/gif';
+
+		console.log(fileType);
 		// eslint-disable-next-line prefer-destructuring
 		const attachmentId = attachment.href.split('documentid=')[1];
-		console.log(attachmentId);
 		// eslint-disable-next-line init-declarations
 		let url;
-		await getDocument(attachmentId, 'messagedoc').then(respUrl => {
+		await getDocument(attachmentId, 'messagedoc', fileType).then(respUrl => {
 			url = respUrl;
-			console.log(url);
 
 			// window.open(url, '_blank');
 			// fecth the url and return the blob
 			fetch(url).then(resp => resp.blob()).then(blob => {
 				// create a new file from the blob
 				const file = new File([blob], attachment.navn, { type: blob.type });
-				console.log(file);
+
+				// only continue if the file is an image
+				if (!file.type.startsWith('image/')) return;
 
 				// create a new image element
 				const img = document.createElement('img');
@@ -124,7 +135,6 @@
 
 				// append the image to the div
 				MessageAttachments = [...MessageAttachments, url];
-				console.log(MessageAttachments);
 				return url;
 			});
 		});
@@ -178,18 +188,37 @@
 					</div>
 				</BrugerPopup>
 
-				<div class="mt-4 mb-4">
-					<div class="flex gap-3">
+				<div class="mt-4 mb-4 w-[calc(100vw-32px)] md:w-[calc(100vw-96px)] 2xl:w-[1280px]">
+					{#each _besked.vedhæftninger as vedhæftning}
+						<div class="hidden">
+							{fetchMessageAttachment(vedhæftning)}
+						</div>
+					{/each}
+					{#if MessageAttachments.length === 0}
 						{#each _besked.vedhæftninger as vedhæftning}
-							<div class="hidden">
-								{fetchMessageAttachment(vedhæftning)}
-							</div>
+							<a
+								class="btn-primary btn-xs btn mr-1 mb-4"
+								href={vedhæftning.href}
+								on:mouseup={() => attemptPreviewAttachment(vedhæftning.href)}>{vedhæftning.navn}</a
+							>
 						{/each}
+					{/if}
 
-						{#each MessageAttachments as attachment}
-							<img src={attachment} alt="" class="rounded-xl h-32" />
-						{/each}
+					<div class="overflow-x-auto">
+						<div class="flex gap-3 w-fit rounded-xl">
+							{#each MessageAttachments as attachment}
+								<div class="rounded-xl h-36 relative group min-w-max">
+									<img src={attachment} alt="" class="rounded-xl h-36" />
+									<div class="absolute top-0">
+										<a href={attachment} target="_blank" class="m-0 btn btn-sm bg-neutral/75 hover:bg-neutral-content/75 filter backdrop-blur-sm border-0 text-neutral-content rounded-tl-xl rounded-bl-none rounded-tr-none rounded-br-md no-animation overflow-hidden opacity-0 group-hover:opacity-100 transition-all duration-100"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-fullscreen" viewBox="0 0 16 16"><path d="M1.5 1a.5.5 0 0 0-.5.5v4a.5.5 0 0 1-1 0v-4A1.5 1.5 0 0 1 1.5 0h4a.5.5 0 0 1 0 1zM10 .5a.5.5 0 0 1 .5-.5h4A1.5 1.5 0 0 1 16 1.5v4a.5.5 0 0 1-1 0v-4a.5.5 0 0 0-.5-.5h-4a.5.5 0 0 1-.5-.5M.5 10a.5.5 0 0 1 .5.5v4a.5.5 0 0 0 .5.5h4a.5.5 0 0 1 0 1h-4A1.5 1.5 0 0 1 0 14.5v-4a.5.5 0 0 1 .5-.5m15 0a.5.5 0 0 1 .5.5v4a1.5 1.5 0 0 1-1.5 1.5h-4a.5.5 0 0 1 0-1h4a.5.5 0 0 0 .5-.5v-4a.5.5 0 0 1 .5-.5"/></svg></a>
+									</div>
+								</div>
+							{/each}
+						</div>
 					</div>
+					{#if MessageAttachments.length > 0 || _besked.vedhæftninger.length > 0}
+						<div class="divider"></div>
+					{/if}
 					<p class="mb-10" use:previewLink>
 						<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 						{@html sanitize(md.render(_besked.besked)).replace('<a', '<a  class="btn btn-xs btn-primary preview" target="_blank"')}


### PR DESCRIPTION
This pull request adds the functionality to preview image attachments in messages. Previously, only the file name was displayed as a link. Now, when a user clicks on the attachment link, the image will be displayed in a modal window. This provides a better user experience and allows users to quickly view image attachments without leaving the page.