### PR TITLE
fix(api): set module notes default to "" rather than "None"

### DIFF
--- a/apps/api/lectio/_modul.py
+++ b/apps/api/lectio/_modul.py
@@ -27,7 +27,7 @@ def modul(self, absid):
             str(
                 soup.find(
                     "textarea", {"id": "s_m_Content_Content_tocAndToolbar_ActNoteTB_tb"}
-                )
+                ) or ""
             ).replace("\r\n", "\n\n"),
             bullets="-",
         )


### PR DESCRIPTION
Prevents frontend from rendering notes when there are none. 